### PR TITLE
Fix helper includes

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,9 +12,9 @@ if( !function_exists( 'add_action' ) ){
 }
 
 // includes
-include('init-car.php');
-include('add-cars.php');
-include('enqueue.php');
+include( plugin_dir_path( __FILE__ ) . 'init-car.php' );
+include( plugin_dir_path( __FILE__ ) . 'add-cars.php' );
+include( plugin_dir_path( __FILE__ ) . 'enqueue.php' );
 
 // actions
 add_action('wp_enqueue_scripts', 'car_enqueue_styles');


### PR DESCRIPTION
## Summary
- use `plugin_dir_path(__FILE__)` for helper includes so WordPress can locate them

## Testing
- `php -l index.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849245ea370832f8341baedbb6aae87